### PR TITLE
Fix AttributeError: 'str' object has no attribute 'is_scope'

### DIFF
--- a/jedi/evaluate/finder.py
+++ b/jedi/evaluate/finder.py
@@ -104,9 +104,8 @@ class NameFinder(object):
         """
         names = []
         if self._context.predefined_names:
-            # TODO is this ok? node might not always be a tree.Name
             node = self._name
-            while node is not None and not node.is_scope():
+            while hasattr(node, 'is_scope') and node.is_scope():
                 node = node.parent
                 if node.type in ("if_stmt", "for_stmt", "comp_for"):
                     try:


### PR DESCRIPTION
This is a quick fix for the exception which can be replicated at sourcegraph.com:

![screenshot from 2018-10-03 17-31-43](https://user-images.githubusercontent.com/120114/46421627-cc9e0380-c732-11e8-9297-7c91df5c731d.png)

I guess a proper fix would be to update `jedi` to upstream, which has fixed the same issue at https://github.com/davidhalter/jedi/commit/febe65f7377bdb9e1c87167e069015c4808cf55d#diff-110b9a827ff585ba881d7ee4d1a0d755R108 — but I thought someone may find this useful anyway.